### PR TITLE
Generate all King moves during double check

### DIFF
--- a/movegen.cpp
+++ b/movegen.cpp
@@ -21,7 +21,14 @@ MoveList::MoveList(const Position& s, Move bestMove, History* history, int ply, 
 		Square k = position.getKingSquare(position.getOurColor());
 		Square c = get_lsb(position.getCheckersBB());
 		valid = between[k][c] | position.getCheckersBB();
-		stage = EvadeBestMove;
+		if (position.inDoubleCheck()) {
+			pushMoves<MoveType::All, PIECETYPE_KING>();
+			checkLegal();
+			stage = AllLegal;
+		}
+		else {
+			stage = EvadeBestMove;
+		}
 	}
 	else {
 		stage = qsearch ? QBestMove : BestMove;
@@ -545,8 +552,8 @@ Move MoveList::getBestMove() {
 /* List of moves and related functions */
 MoveList::MoveList(const Position& s) : position(s), valid(FULL), isQSearch(false), best(NULL_MOVE), sz(0), history(nullptr), ply(0) {
 	generateMoves<MoveType::All>();
-	stage = AllLegal;
 	checkLegal();
+	stage = AllLegal;
 }
 
 std::ostream& operator<<(std::ostream& os, const MoveList& moveList) {


### PR DESCRIPTION
```
position fen 6k1/2p3p1/1p1b3p/p2P2r1/P1PP4/7P/1B2RP2/3Q1qK1 w - - 0 29
go
info depth 1 score cp 1064 time 0 nodes 1 nps 1000 pv g1f1 
info depth 2 score cp 1072 time 0 nodes 4 nps 4000 pv g1f1 g5f5 f1g1 
info depth 3 score cp 1154 time 0 nodes 44 nps 44000 pv g1f1 g8f8 e2e6 
info depth 4 score cp 1152 time 0 nodes 99 nps 99000 pv g1f1 g8f8 e2e6 g5f5 f1g1 
info depth 5 score cp 1174 time 1 nodes 369 nps 184000 pv g1f1 g8f7 e2e6 
info depth 6 score cp 1114 time 3 nodes 894 nps 223000 pv g1f1 g5f5 e2e8 f5f8 e8f8 g8f8 
info depth 7 score cp 1194 time 6 nodes 1768 nps 252000 pv g1f1 g5f5 d1c2 f5f8 c4c5 d6f4 e2e7
...
```